### PR TITLE
Fix discount rule for professional clients

### DIFF
--- a/src/main/java/com/client/paris/ClientProfessionnel.java
+++ b/src/main/java/com/client/paris/ClientProfessionnel.java
@@ -16,7 +16,7 @@ public class ClientProfessionnel extends Client {
 
     @Override
     public double getUnitPrice(ProductType type) {
-        boolean grosClient = chiffreAffaire > 10_000_000;
+        boolean grosClient = chiffreAffaire >= 10_000_000;
         return switch (type) {
             case TEL_HAUT_DE_GAMME -> grosClient ? 1000 : 1150;
             case TEL_MOYENNE_GAMME -> grosClient ? 550 : 600;

--- a/src/test/java/com/client/paris/CartCalculatorTest.java
+++ b/src/test/java/com/client/paris/CartCalculatorTest.java
@@ -33,6 +33,11 @@ public class CartCalculatorTest {
                         "Client pro CA > 10M",
                         new ClientProfessionnel("3", "BigCorp", null, "987654321", 15_000_000),
                         1000 + 2 * 550 + 900  // = 3000
+                ),
+                new TestCase(
+                        "Client pro CA = 10M",
+                        new ClientProfessionnel("4", "Moyenne", "FR987", "456789123", 10_000_000),
+                        1000 + 2 * 550 + 900  // = 3000
                 )
         );
     }


### PR DESCRIPTION
## Summary
- adjust discount threshold for professional clients to include 10M CA
- test that a CA of exactly 10M gets the discounted prices

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c0860cc832c9de647a0bf1855d9